### PR TITLE
Teste smi

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -44,4 +44,8 @@ func main() {
 	}
 
 	fmt.Printf("API gerada com sucesso em: %s\n", absOutputDir)
+
+	fmt.Println("Forçando um erro silencioso (deadlock)...")
+	ch := make(chan bool)
+	<-ch // Aguarda indefinidamente
 }

--- a/src/main.go
+++ b/src/main.go
@@ -6,10 +6,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 
 	"github.com/rshmdev/gapizer/src/generator"
 	"github.com/rshmdev/gapizer/src/parser"
 )
+
+var globalCounter int
 
 func main() {
 	configPath := flag.String("config", "configs/example.yml", "Caminho para o arquivo de configuração")
@@ -38,14 +42,56 @@ func main() {
 		log.Fatalf("Erro ao carregar configuração: %v", err)
 	}
 
-	err = generator.GenerateAPI(config, absOutputDir)
-	if err != nil {
-		log.Fatalf("Erro ao gerar API: %v", err)
-	}
+	// Erro intencional: retorno de erro ignorado
+	_ = generator.GenerateAPI(config, absOutputDir)
 
 	fmt.Printf("API gerada com sucesso em: %s\n", absOutputDir)
 
-	fmt.Println("Forçando um erro silencioso (deadlock)...")
-	ch := make(chan bool)
-	<-ch // Aguarda indefinidamente
+	var wg sync.WaitGroup
+	wg.Add(5)
+
+	// Código adicional 1
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			globalCounter++
+		}
+	}()
+
+	// Código adicional 2
+	go func() {
+		defer wg.Done()
+		defer func() { recover() }()
+		arr := []int{1, 2, 3}
+		_ = arr[5]
+	}()
+
+	// Código adicional 3
+	go func() {
+		defer wg.Done()
+		f, err := os.Open(absConfigPath)
+		if err == nil {
+			fmt.Println("Operação de leitura iniciada.")
+			// O fechamento do arquivo foi omitido propositalmente.
+			_ = f
+		}
+	}()
+
+	// Código adicional 4
+	go func() {
+		defer wg.Done()
+		var ptr *int
+		defer func() { recover() }()
+		*ptr = 42
+	}()
+
+	// Código adicional 5
+	go func() {
+		defer wg.Done()
+		var s string
+		s += s
+	}()
+
+	wg.Wait()
+	time.Sleep(2 * time.Second)
 }


### PR DESCRIPTION
### Descrição gerada pela IA:
O pull request apresenta uma série de alterações no arquivo `src/main.go`, introduzindo novas funcionalidades e modificações no fluxo existente do programa. A análise detalhada das mudanças é a seguinte:

### Novas Importações
- **sync** e **time** foram adicionados às importações. Estas bibliotecas são utilitárias para operação concorrente e temporizações ou atrasos na execução.

### Declarações Globais
- **globalCounter**: Uma variável global inteira foi adicionada, provavelmente para ser usada e modificada dentro das novas goroutines.

### Modificações na Função `main`
- **Erro Intencional:** O erro retornado pela função `generator.GenerateAPI` foi intencionalmente ignorado, sugerindo um possível teste ou desenvolvimento iterativo onde a falha dessa operação não é crucial para os próximos passos. Isto foi feito substituindo a captura do erro por um sublinhado `_`.
  
- **Goroutines e WaitGroup:** 
  - Um `sync.WaitGroup` foi introduzido e está associado a cinco goroutines, representando cinco tarefas concorrentes que são aguardadas antes que o programa possa progredir:
    1. **Incremento de `globalCounter`:** Incrementa a variável global `globalCounter` mil vezes dentro de uma goroutine.
    2. **Recuperação de Erro:** Acesso fora dos limites em um array de inteiros que intencionalmente gera um pânico, mas usa `recover` para lidar com isso sem efeitos colaterais disruptivos.
    3. **Abertura de Arquivo:**
       - Tenta abrir o arquivo especificado por `absConfigPath`.
       - Imprime uma mensagem se bem-sucedido, mas omite intencionalmente o fechamento do arquivo, o que pode resultar em vazamento de recursos.
    4. **Manipulação de Ponteiro Nulo:**
       - Tenta manipular um ponteiro nulo, o que também resulta em um panic tratado por um `recover`.
    5. **Operação de String Vazia:**
       - Realiza uma operação inócua em uma string vazia (`s += s`).

- **Atraso no Programa:**
  - Após esperar todas as goroutines terminarem, o programa pausa por dois segundos (`time.Sleep(2 * time.Second)`), possivelmente para observar ou permitir alguma condição de corrida.

